### PR TITLE
Release pingrep v23.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,7 +1523,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingrep"
-version = "23.11.0"
+version = "23.11.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pingrep"
-version = "23.11.0"
+version = "23.11.1"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 repository = "https://github.com/zoni/pingrep/"


### PR DESCRIPTION
     Changes for pingrep from v23.11.0 to 23.11.1
             b7539b8 Release pingrep v23.11.1
             1ceb604 Create release tag through GitHub API
             a927af0 Run entire version-bump workflow as robot account
             1f4fdb2 List changes in release-new-version PR body
             eb19b3e cargo-dist: only run plans in PRs, not builds
             f053bfe cargo-dist: disable homebrew, enable powershell installer
             ee61564 Run version-bump workflow with a robot account
             793894a Move release-new-version code from GHA into Justfile
             9e6ea5b Give version-bump workflow write access to pull-requests
             5ea0923 Fetch tags and increase depth during clone for bump-release
             0c6832a Set GH token permissions in version-bump workflow