### PR TITLE
Release pingrep v23.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,7 +1523,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingrep"
-version = "23.11.2"
+version = "23.12.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pingrep"
-version = "23.11.2"
+version = "23.12.0"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 repository = "https://github.com/zoni/pingrep/"


### PR DESCRIPTION
warning: main is behind origin/main
     Changes for pingrep from v23.11.0 to 23.12.0
             b47a6be Release pingrep v23.12.0
             7e93e0d Enable aarch64 builds for non-MacOS platforms
             e58fac2 Bump clap from 4.4.7 to 4.4.10
             cd41ef1 Bump open from 5.0.0 to 5.0.1
             1ff4e7c Bump serde from 1.0.190 to 1.0.193
             c7710cc Bump openssl from 0.10.59 to 0.10.60
             3accff3 Release pingrep v23.11.2
             13003d4 Make yaml file extensions consistently in .github/workflows
             671bd7a Publish releases to crates.io
             1a10597 Configure dependabot
             0daa610 Release pingrep v23.11.1 (#12)
             2f22dd3 Remove `-rs` suffix from project directory
             2680bde Create release tag through GitHub API
             a927af0 Run entire version-bump workflow as robot account
             1f4fdb2 List changes in release-new-version PR body
             eb19b3e cargo-dist: only run plans in PRs, not builds
             f053bfe cargo-dist: disable homebrew, enable powershell installer
             793894a Move release-new-version code from GHA into Justfile