### PR TITLE
Release pingrep v24.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingrep"
-version = "24.3.0"
+version = "24.5.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pingrep"
-version = "24.3.0"
+version = "24.5.0"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 repository = "https://github.com/zoni/pingrep/"


### PR DESCRIPTION
     Changes for pingrep from v23.11.0 to 24.5.0
             f062306 Release pingrep v24.5.0
             a40a41c Switch from Dependabot to Renovate
             df040f1 Build Linux binary on ubuntu-latest runner
             edaba8b Upgrade to cargo-dist 0.14.1
             d1014d0 Release pingrep v24.3.0 (#23)
             84f2bf7 Bump serde_json from 1.0.108 to 1.0.114 (#56)
             0ef68ef Bump os_pipe from 1.1.4 to 1.1.5
             7cc1e69 Bump keyring from 2.0.5 to 2.3.2
             43394df Bump chrono from 0.4.31 to 0.4.35 (#55)
             0ccc0f3 Bump clap from 4.4.10 to 4.5.2
             84c9b05 Build on push only
             d0112bc Bump reqwest from 0.11.22 to 0.11.24
             c4c70e1 Bump duct from 0.13.6 to 0.13.7
             ed77bb7 Bump actions/cache from 3 to 4
             fae13bf Bump actions/setup-python from 4 to 5
             0428549 Bump snafu from 0.7.5 to 0.8.2
             134b403 Bump textwrap from 0.16.0 to 0.16.1
             951bc00 Bump serde from 1.0.193 to 1.0.197
             88ec4d6 Bump clap from 4.4.10 to 4.5.1
             cc6cb44 Bump anyhow from 1.0.75 to 1.0.80
             0544686 Bump open from 5.0.1 to 5.0.2
             cb1e91c Bump tempfile from 3.8.1 to 3.10.1
             dbd0d6e Bump mio from 0.8.9 to 0.8.11
             4832d43 Bump h2 from 0.3.21 to 0.3.24
             c75704b Release pingrep v23.12.1
             0923eb8 Disable unsupported aarch64 builds again
             0bf038f Release pingrep v23.12.0
             7e93e0d Enable aarch64 builds for non-MacOS platforms
             0ba764c Bump rpassword from 7.2.0 to 7.3.1
             e58fac2 Bump clap from 4.4.7 to 4.4.10
             cd41ef1 Bump open from 5.0.0 to 5.0.1
             1ff4e7c Bump serde from 1.0.190 to 1.0.193
             c7710cc Bump openssl from 0.10.59 to 0.10.60
             3accff3 Release pingrep v23.11.2
             13003d4 Make yaml file extensions consistently in .github/workflows
             671bd7a Publish releases to crates.io
             0daa610 Release pingrep v23.11.1 (#12)
             2f22dd3 Remove `-rs` suffix from project directory
             2680bde Create release tag through GitHub API
             a927af0 Run entire version-bump workflow as robot account
             1f4fdb2 List changes in release-new-version PR body
             eb19b3e cargo-dist: only run plans in PRs, not builds
             f053bfe cargo-dist: disable homebrew, enable powershell installer
             793894a Move release-new-version code from GHA into Justfile